### PR TITLE
Utilize HashMap instead of BTreeMap

### DIFF
--- a/src/types/feature.rs
+++ b/src/types/feature.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use rustc_serialize::json::{Json, Object, ToJson};
 use {Geometry, GeoJsonResult};
 
@@ -27,7 +27,7 @@ pub struct Feature {
 
 impl ToJson for Feature {
     fn to_json(&self) -> Json {
-        let mut d = BTreeMap::new();
+        let mut d = HashMap::new();
         d.insert(format!("type"), "Feature".to_json());
         d.insert(format!("geometry"), self.geometry.to_json());
         d.insert(format!("properties"), self.properties.to_json());
@@ -47,13 +47,13 @@ impl Feature {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::collections::HashMap;
     use rustc_serialize::json::ToJson;
     use {Geometry, Feature, Poly, MultiPolygon, Pos, Ring};
 
     #[test]
     fn test_feature_to_json() {
-        let mut map = BTreeMap::new();
+        let mut map = HashMap::new();
         map.insert(format!("hi"), "there".to_json());
         let point = Feature {
             geometry: Geometry::MultiPolygon(MultiPolygon {

--- a/src/types/featurecollection.rs
+++ b/src/types/featurecollection.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use rustc_serialize::json::{Json, ToJson, Object};
 use {Feature, GeoJsonResult, GeoJsonError};
 
@@ -26,7 +26,7 @@ pub struct FeatureCollection {
 
 impl ToJson for FeatureCollection {
     fn to_json(&self) -> Json {
-        let mut d = BTreeMap::new();
+        let mut d = HashMap::new();
         d.insert(format!("type"), "FeatureCollection".to_json());
         d.insert(format!("features"), self.features.to_json());
         d.to_json()
@@ -53,13 +53,13 @@ impl FeatureCollection {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::collections::HashMap;
     use rustc_serialize::json::ToJson;
     use {FeatureCollection, Feature, MultiPolygon, Geometry, Poly, Pos, Ring};
 
     #[test]
     fn test_feature_collection_to_json() {
-        let mut map = BTreeMap::new();
+        let mut map = HashMap::new();
         map.insert(format!("hi"), "there".to_json());
         let point = FeatureCollection {
             features:vec![

--- a/src/types/geometrycollection.rs
+++ b/src/types/geometrycollection.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use rustc_serialize::json::{Json, ToJson, Object};
 use {Geometry, GeoJsonResult};
 
@@ -26,7 +26,7 @@ pub struct GeometryCollection {
 
 impl ToJson for GeometryCollection {
     fn to_json(&self) -> Json {
-        let mut d = BTreeMap::new();
+        let mut d = HashMap::new();
         d.insert(format!("type"), "GeometryCollection".to_json());
         d.insert(format!("geometries"), self.geometries.to_json());
         d.to_json()

--- a/src/types/linestring.rs
+++ b/src/types/linestring.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use rustc_serialize::json::{Json, ToJson, Object};
 use {Ring, GeoJsonResult};
 
@@ -26,7 +26,7 @@ pub struct LineString {
 
 impl ToJson for LineString {
     fn to_json(&self) -> Json {
-        let mut d = BTreeMap::new();
+        let mut d = HashMap::new();
         d.insert(format!("type"), "LineString".to_json());
         d.insert(format!("coordinates"), self.coordinates.to_json());
         d.to_json()

--- a/src/types/multilinestring.rs
+++ b/src/types/multilinestring.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use rustc_serialize::json::{Json, ToJson, Object};
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use {Ring, GeoJsonResult};
 
 /// MultiLineString
@@ -26,7 +26,7 @@ pub struct MultiLineString {
 
 impl ToJson for MultiLineString {
     fn to_json(&self) -> Json {
-        let mut d = BTreeMap::new();
+        let mut d = HashMap::new();
         d.insert(format!("type"), "MultiLineString".to_json());
         d.insert(format!("coordinates"), self.coordinates.to_json());
         d.to_json()

--- a/src/types/multipoint.rs
+++ b/src/types/multipoint.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use rustc_serialize::json::{Json, ToJson, Object};
 use {Pos, GeoJsonResult};
 
@@ -26,7 +26,7 @@ pub struct MultiPoint {
 
 impl ToJson for MultiPoint {
     fn to_json(&self) -> Json {
-        let mut d = BTreeMap::new();
+        let mut d = HashMap::new();
         d.insert(format!("type"), "MultiPoint".to_json());
         d.insert(format!("coordinates"), self.coordinates.to_json());
         d.to_json()

--- a/src/types/multipolygon.rs
+++ b/src/types/multipolygon.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use rustc_serialize::json::{Json, ToJson, Object};
 use {Poly, GeoJsonResult};
 
@@ -26,7 +26,7 @@ pub struct MultiPolygon {
 
 impl ToJson for MultiPolygon {
     fn to_json(&self) -> Json {
-        let mut d = BTreeMap::new();
+        let mut d = HashMap::new();
         d.insert(format!("type"), "MultiPolygon".to_json());
         d.insert(format!("coordinates"), self.coordinates.to_json());
         d.to_json()

--- a/src/types/point.rs
+++ b/src/types/point.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use rustc_serialize::json::{Json, ToJson, Object};
 use {Pos, GeoJsonResult};
 
@@ -26,7 +26,7 @@ pub struct Point {
 
 impl ToJson for Point {
     fn to_json(&self) -> Json {
-        let mut d = BTreeMap::new();
+        let mut d = HashMap::new();
         d.insert(format!("type"), "Point".to_json());
         d.insert(format!("coordinates"), self.coordinates.to_json());
         d.to_json()

--- a/src/types/polygon.rs
+++ b/src/types/polygon.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use rustc_serialize::json::{Json, ToJson, Object};
 use {Poly, GeoJsonResult};
 
@@ -26,7 +26,7 @@ pub struct Polygon {
 
 impl ToJson for Polygon {
     fn to_json(&self) -> Json {
-        let mut d = BTreeMap::new();
+        let mut d = HashMap::new();
         d.insert(format!("type"), "Polygon".to_json());
         d.insert(format!("coordinates"), self.coordinates.to_json());
         d.to_json()


### PR DESCRIPTION
Relevant documentation:
http://doc.rust-lang.org/std/collections/index.html#when-should-you-use-which-collection?

It looks like BTreeMap offers additional functionality we don't need for
our use case. In particular, we don't need our map items sorted.