### PR TITLE
Only allow Object or Null value for Feature properties

### DIFF
--- a/src/types/featurecollection.rs
+++ b/src/types/featurecollection.rs
@@ -53,13 +53,13 @@ impl FeatureCollection {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
     use rustc_serialize::json::ToJson;
     use {FeatureCollection, Feature, MultiPolygon, Geometry, Poly, Pos, Ring};
 
     #[test]
     fn test_feature_collection_to_json() {
-        let mut map = HashMap::new();
+        let mut map = BTreeMap::new();
         map.insert(format!("hi"), "there".to_json());
         let point = FeatureCollection {
             features:vec![
@@ -78,7 +78,7 @@ mod tests {
                         ])
                     ]
                 }),
-                properties: map.to_json()
+                properties: Some(map)
             }
         ]};
         let json_string = format!("{}",point.to_json());


### PR DESCRIPTION
Prior to this change, one could do something like:

{"type": "Feature", geometry: ..., properties: 87}

or

{"type": "Feature", geometry: ..., properties: [1,2,3]}

Both of which are invalid per the GeoJSON spec:

'A feature object must have a member with the name "properties". The
value of the properties member is an object (any JSON object or a JSON
null value).'