### PR TITLE
Serde Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ rust:
   - nightly
   - beta
   - stable
+env:
+  - FEATURES=""
+  - FEATURES="with-serde"
+script:
+  - cargo build --features "$FEATURES"
+  - cargo test --features "$FEATURES"
 after_success: |
   cargo doc && \
   echo '<meta http-equiv=refresh content=0;url=geojson/index.html>' > target/doc/index.html && \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,11 @@ readme = "README.md"
 documentation = "https://georust.github.io/rust-geojson/"
 keywords = ["geojson", "gis", "json", "geo"]
 
+[features]
+default = ["rustc-serialize"]
+with-serde = ["serde","serde_json"]
+
 [dependencies]
-rustc-serialize = "0.3"
+rustc-serialize = { version = "0.3", optional = true }
+serde = { version = "~0.7", optional = true }
+serde_json = { version = "~0.7", optional = true }

--- a/src/crs.rs
+++ b/src/crs.rs
@@ -14,7 +14,12 @@
 
 use std::collections::BTreeMap;
 
-use rustc_serialize::json::{self, ToJson};
+#[cfg(not(feature = "with-serde"))]
+use ::json::ToJson;
+#[cfg(feature = "with-serde")]
+use ::json::{Serialize, Deserialize, Serializer, Deserializer, SerdeError};
+
+use ::json::{JsonValue, JsonObject, json_val};
 
 use ::{Error, FromObject};
 
@@ -43,39 +48,40 @@ pub enum Crs {
     },
 }
 
-impl<'a> From<&'a Crs> for json::Object {
-    fn from(crs: &'a Crs) -> json::Object {
+impl<'a> From<&'a Crs> for JsonObject {
+    fn from(crs: &'a Crs) -> JsonObject {
         let mut crs_map = BTreeMap::new();
         let mut properties_map = BTreeMap::new();
         match *crs {
             Crs::Named{ref name} => {
-                crs_map.insert(String::from("type"), "name".to_json());
-                properties_map.insert(String::from("name"), name.to_json());
+                crs_map.insert(String::from("type"), json_val(&String::from("name")));
+                properties_map.insert(String::from("name"), json_val(name));
             }
             Crs::Linked{ref href, ref type_} => {
-                crs_map.insert(String::from("type"), "link".to_json());
-                properties_map.insert(String::from("href"), href.to_json());
+                crs_map.insert(String::from("type"), json_val(&String::from("link")));
+                properties_map.insert(String::from("href"), json_val(href));
                 if let Some(ref type_) = *type_ {
-                    properties_map.insert(String::from("type"), type_.to_json());
+                    properties_map.insert(String::from("type"), json_val(type_));
                 }
             }
         };
-        crs_map.insert(String::from("properties"), properties_map.to_json());
+        crs_map.insert(String::from("properties"), json_val(&properties_map));
         return crs_map;
     }
 }
 
 impl FromObject for Crs {
-    fn from_object(object: &json::Object) -> Result<Self, Error> {
+    fn from_object(object: &JsonObject) -> Result<Self, Error> {
         let type_ = expect_type!(object);
         let properties = expect_object!(expect_property!(object, "properties", "Encountered CRS object type with no properties"));
+
         return Ok(match type_ {
             "name" => {
-                let name = expect_string!(expect_property!(properties, "name", "Encountered Named CRS object with no name"));
+                let name = expect_string!(expect_property!(&properties, "name", "Encountered Named CRS object with no name"));
                 Crs::Named {name: String::from(name)}
             },
             "link" => {
-                let href = expect_string!(expect_property!(properties, "href", "Encountered Linked CRS object with no link")).to_string();
+                let href = expect_string!(expect_property!(&properties, "href", "Encountered Linked CRS object with no link")).to_string();
                 let type_ = match properties.get("type") {
                     Some(type_) => Some(expect_string!(type_).to_string()),
                     None => None,
@@ -87,8 +93,34 @@ impl FromObject for Crs {
     }
 }
 
+#[cfg(not(feature = "with-serde"))]
 impl ToJson for Crs {
-    fn to_json(&self) -> json::Json {
-        return json::Json::Object(self.into());
+    fn to_json(&self) -> JsonValue {
+        return ::rustc_serialize::json::Json::Object(self.into());
+    }
+}
+
+#[cfg(feature = "with-serde")]
+impl Serialize for Crs {
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+    where S: Serializer {
+        JsonObject::from(self).serialize(serializer)
+    }
+}
+
+#[cfg(feature = "with-serde")]
+impl Deserialize for Crs {
+    fn deserialize<D>(deserializer: &mut D) -> Result<Crs, D::Error>
+    where D: Deserializer {
+        use std::error::Error as StdError;
+
+        let val = try!(JsonValue::deserialize(deserializer));
+
+        if let Some(crs) = val.as_object() {
+            Crs::from_object(crs).map_err(|e| D::Error::custom(e.description()))
+        }
+        else {
+            Err(D::Error::custom("expected json object"))
+        }
     }
 }

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -14,8 +14,12 @@
 
 use std::collections::BTreeMap;
 
-use rustc_serialize::json::{self, Json, ToJson};
+#[cfg(not(feature = "with-serde"))]
+use ::json::ToJson;
+#[cfg(feature = "with-serde")]
+use ::json::{Serialize, Deserialize, Serializer, Deserializer, SerdeError};
 
+use ::json::{JsonValue, JsonObject, json_val};
 use ::{Bbox, Crs, Error, FromObject, Geometry, util};
 
 
@@ -28,33 +32,34 @@ pub struct Feature {
     pub bbox: Option<Bbox>,
     pub crs: Option<Crs>,
     pub geometry: Geometry,
-    pub id: Option<json::Json>,
-    pub properties: Option<json::Object>,
+    pub id: Option<JsonValue>,
+    pub properties: Option<JsonObject>,
 }
 
-impl<'a> From<&'a Feature> for json::Object {
-    fn from(feature: &'a Feature) -> json::Object {
+impl<'a> From<&'a Feature> for JsonObject {
+    fn from(feature: &'a Feature) -> JsonObject {
         let mut map = BTreeMap::new();
-        map.insert(String::from("type"), "Feature".to_json());
-        map.insert(String::from("geometry"), feature.geometry.to_json());
+        map.insert(String::from("type"), json_val(&String::from("Feature")));
+        map.insert(String::from("geometry"), json_val(&feature.geometry));
         if let Some(ref properties) = feature.properties {
-            map.insert(String::from("properties"), properties.to_json());
+            map.insert(String::from("properties"), json_val(properties));
         }
         if let Some(ref crs) = feature.crs {
-            map.insert(String::from("crs"), crs.to_json());
+            map.insert(String::from("crs"), json_val(crs));
         }
         if let Some(ref bbox) = feature.bbox {
-            map.insert(String::from("bbox"), bbox.to_json());
+            map.insert(String::from("bbox"), json_val(bbox));
         }
         if let Some(ref id) = feature.id {
-            map.insert(String::from("id"), id.to_json());
+            map.insert(String::from("id"), json_val(id));
         }
+
         return map;
     }
 }
 
 impl FromObject for Feature {
-    fn from_object(object: &json::Object) -> Result<Self, Error> {
+    fn from_object(object: &JsonObject) -> Result<Self, Error> {
         return Ok(Feature{
             geometry: try!(util::get_geometry(object)),
             properties: try!(util::get_properties(object)),
@@ -65,41 +70,105 @@ impl FromObject for Feature {
     }
 }
 
+#[cfg(not(feature = "with-serde"))]
 impl ToJson for Feature {
-    fn to_json(&self) -> json::Json {
-        return json::Json::Object(self.into());
+    fn to_json(&self) -> ::rustc_serialize::json::Json {
+        return ::rustc_serialize::json::Json::Object(self.into());
+    }
+}
+
+#[cfg(feature = "with-serde")]
+impl Serialize for Feature {
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+    where S: Serializer {
+        JsonObject::from(self).serialize(serializer)
+    }
+}
+
+#[cfg(feature = "with-serde")]
+impl Deserialize for Feature {
+    fn deserialize<D>(deserializer: &mut D) -> Result<Feature, D::Error>
+    where D: Deserializer {
+        use std::error::Error as StdError;
+
+        let val = try!(JsonValue::deserialize(deserializer));
+
+        if let Some(feature) = val.as_object() {
+            Feature::from_object(feature).map_err(|e| D::Error::custom(e.description()))
+        }
+        else {
+            Err(D::Error::custom("expected json object"))
+        }
     }
 }
 
 
 #[cfg(test)]
 mod tests {
-    use rustc_serialize::json::{self, ToJson};
-    use super::super::{Feature, GeoJson, Geometry, Value};
+    use ::{Feature, Geometry, Value, GeoJson};
 
+    fn feature_json_str() -> &'static str {
+        "{\"geometry\":{\"coordinates\":[1.1,2.1],\"type\":\"Point\"},\"properties\":{},\"type\":\"Feature\"}"
+    }
 
-    #[test]
-    fn encode_decode_feature() {
-        let feature_json_str = "{\"geometry\":{\"coordinates\":[1.0,2.0],\"type\":\"Point\"},\"properties\":{},\"type\":\"Feature\"}";
-        let feature = Feature {
+    #[cfg(not(feature = "with-serde"))]
+    fn properties() -> Option<::json::JsonObject> {
+        Some(::rustc_serialize::json::Object::new())
+    }
+    #[cfg(feature = "with-serde")]
+    fn properties() -> Option<::json::JsonObject> {
+        use std::collections::BTreeMap;
+
+        Some(BTreeMap::new())
+    }
+
+    fn feature() -> Feature {
+        ::Feature {
             geometry: Geometry {
-                value: Value::Point(vec![1., 2.]),
+                value: Value::Point(vec![1.1, 2.1]),
                 crs: None,
                 bbox: None,
             },
-            properties: Some(json::Object::new()),
+            properties: properties(),
             crs: None,
             bbox: None,
             id: None,
-        };
+        }
+    }
+
+    #[cfg(not(feature = "with-serde"))]
+    fn encode(feature: &Feature) -> String {
+        use rustc_serialize::json::{self, ToJson};
+
+        json::encode(&feature.to_json()).unwrap()
+    }
+    #[cfg(feature = "with-serde")]
+    fn encode(feature: &Feature) -> String {
+        use serde_json;
+
+        serde_json::to_string(&feature).unwrap()
+    }
+
+    #[cfg(not(feature = "with-serde"))]
+    fn decode(json_string: String) -> GeoJson {
+        json_string.parse().unwrap()
+    }
+    #[cfg(feature = "with-serde")]
+    fn decode(json_string: String) -> GeoJson {
+        json_string.parse().unwrap()
+    }
+
+    #[test]
+    fn encode_decode_feature() {
+        let feature = feature();
 
         // Test encoding
-        let json_string = json::encode(&feature.to_json()).unwrap();
-        assert_eq!(json_string, feature_json_str);
+        let json_string = encode(&feature);
+        assert_eq!(json_string, feature_json_str());
 
         // Test decoding
-        let decoded_feature = match json_string.parse() {
-            Ok(GeoJson::Feature(f)) => f,
+        let decoded_feature = match decode(json_string) {
+            GeoJson::Feature(f) => f,
             _ => unreachable!(),
         };
         assert_eq!(decoded_feature, feature);

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -14,7 +14,12 @@
 
 use std::collections::BTreeMap;
 
-use rustc_serialize::json::{self, Json, ToJson};
+#[cfg(not(feature = "with-serde"))]
+use ::json::ToJson;
+#[cfg(feature = "with-serde")]
+use ::json::{Serialize, Deserialize, Serializer, Deserializer, SerdeError};
+
+use ::json::{JsonValue, JsonObject, json_val};
 
 use ::{Bbox, Crs, Error, Feature, FromObject, util};
 
@@ -31,18 +36,18 @@ pub struct FeatureCollection {
 }
 
 
-impl<'a> From<&'a FeatureCollection> for json::Object {
-    fn from(fc: &'a FeatureCollection) -> json::Object {
+impl<'a> From<&'a FeatureCollection> for JsonObject {
+    fn from(fc: &'a FeatureCollection) -> JsonObject {
         let mut map = BTreeMap::new();
-        map.insert(String::from("type"), "FeatureCollection".to_json());
-        map.insert(String::from("features"), fc.features.to_json());
+        map.insert(String::from("type"), json_val(&String::from("FeatureCollection")));
+        map.insert(String::from("features"), json_val(&fc.features));
 
         if let Some(ref crs) = fc.crs {
-            map.insert(String::from("crs"), crs.to_json());
+            map.insert(String::from("crs"), json_val(crs));
         }
 
         if let Some(ref bbox) = fc.bbox {
-            map.insert(String::from("bbox"), bbox.to_json());
+            map.insert(String::from("bbox"), json_val(bbox));
         }
 
         return map;
@@ -50,7 +55,7 @@ impl<'a> From<&'a FeatureCollection> for json::Object {
 }
 
 impl FromObject for FeatureCollection {
-    fn from_object(object: &json::Object) -> Result<Self, Error> {
+    fn from_object(object: &JsonObject) -> Result<Self, Error> {
         return Ok(FeatureCollection{
             bbox: try!(util::get_bbox(object)),
             features: try!(util::get_features(object)),
@@ -59,8 +64,34 @@ impl FromObject for FeatureCollection {
     }
 }
 
+#[cfg(not(feature = "with-serde"))]
 impl ToJson for FeatureCollection {
-    fn to_json(&self) -> json::Json {
-        return json::Json::Object(self.into());
+    fn to_json(&self) -> JsonValue {
+        return ::rustc_serialize::json::Json::Object(self.into());
+    }
+}
+
+#[cfg(feature = "with-serde")]
+impl Serialize for FeatureCollection {
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+    where S: Serializer {
+        JsonObject::from(self).serialize(serializer)
+    }
+}
+
+#[cfg(feature = "with-serde")]
+impl Deserialize for FeatureCollection {
+    fn deserialize<D>(deserializer: &mut D) -> Result<FeatureCollection, D::Error>
+    where D: Deserializer {
+        use std::error::Error as StdError;
+
+        let val = try!(JsonValue::deserialize(deserializer));
+
+        if let Some(features) = val.as_object() {
+            FeatureCollection::from_object(features).map_err(|e| D::Error::custom(e.description()))
+        }
+        else {
+            Err(D::Error::custom("expected json object"))
+        }
     }
 }

--- a/src/lib.rustc_serialize.rs.in
+++ b/src/lib.rustc_serialize.rs.in
@@ -1,0 +1,10 @@
+extern crate rustc_serialize;
+
+#[doc(hidden)]
+mod json {
+    pub fn json_val<T: ToJson>(val: &T) -> JsonValue {
+        (*val).to_json()
+    }
+
+    pub use rustc_serialize::json::{ Json as JsonValue, Object as JsonObject, ToJson };
+}

--- a/src/lib.serde.rs.in
+++ b/src/lib.serde.rs.in
@@ -1,0 +1,17 @@
+extern crate serde;
+extern crate serde_json;
+
+#[doc(hidden)]
+mod json {
+    use std::collections::BTreeMap;
+
+    use serde_json::Value;
+
+    pub fn json_val<T: ?Sized + Serialize>(val: &T) -> Value {
+        ::serde_json::value::to_value(val)
+    }
+
+    pub use serde::{ Serialize, Deserialize, Serializer, Deserializer, Error as SerdeError };
+    pub use serde_json::Value as JsonValue;
+    pub type JsonObject = BTreeMap<String, JsonValue>;
+}


### PR DESCRIPTION
Closes #40 

I thought I'd make a PR for my progress sooner rather than later to get some feedback on the approach. Default framework is `rustc_serialize`, so user-code shouldn't have to change. Serde is feature-gated by `with_serde`.

I've tried to abstract the concept of `JsonValue` and `JsonObject` between `rustc_serialize` and `serde` so that stuff like `Feature` don't need duplicate fields for each framework.

Serialization also looks like it's a two-hop process right now? `json string -> json tree (serde_json::Value or rustc_serialize::json::Object) -> T`, rather than just `json string -> T`. I'm trying to make as few changes as necessary though so haven't given it much thought.

(Stable will work when I finish redoing the other modules, only `Feature` is done so far)