### PR TITLE
Permit `geometry` field on `feature` objects to be `null`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,5 @@
+# Changes
+
+## 0.3.0
+
+* [Permit `geometry` field on `feature` objects to be `null`](https://github.com/georust/rust-geojson/issues/42)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "geojson"
 description = "Library for serializing the GeoJSON vector GIS file format"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Corey Farwell <coreyf@rwell.org>",
            "Blake Grotewold <hello@grotewold.me>"]
 license = "MIT/Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ properties.insert(
 let geojson = GeoJson::Feature(Feature {
     crs: None,
     bbox: None,
-    geometry: geometry,
+    geometry: Some(geometry),
     id: None,
     properties: Some(properties),
 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@
 //! let geojson = GeoJson::Feature(Feature {
 //!     crs: None,
 //!     bbox: None,
-//!     geometry: geometry,
+//!     geometry: Some(geometry),
 //!     id: None,
 //!     properties: Some(properties),
 //! });
@@ -171,6 +171,7 @@ pub enum Error {
     GeometryUnknownType,
     MalformedJson,
     PropertiesExpectedObjectOrNull,
+    FeatureInvalidGeometryValue,
 
     // FIXME: make these types more specific
     ExpectedStringValue,
@@ -209,6 +210,10 @@ impl std::fmt::Display for Error {
                 // FIXME: inform what type we actually found
                 write!(f, "Encountered neither object type nor null type for \
                            'properties' object."),
+            Error::FeatureInvalidGeometryValue =>
+                // FIXME: inform what type we actually found
+                write!(f, "Encountered neither object type nor null type for \
+                           'geometry' field on 'feature' object."),
             Error::ExpectedStringValue =>
                 write!(f, "Expected a string value."),
             Error::ExpectedProperty =>
@@ -236,6 +241,8 @@ impl std::error::Error for Error {
             Error::MalformedJson => "malformed JSON",
             Error::PropertiesExpectedObjectOrNull =>
                 "neither object type nor null type for properties' object.",
+            Error::FeatureInvalidGeometryValue =>
+                "neither object type nor null type for 'geometry' field on 'feature' object.",
             Error::ExpectedStringValue => "expected a string value",
             Error::ExpectedProperty => "expected a GeoJSON 'property'",
             Error::ExpectedF64Value => "expected a floating-point value",

--- a/src/util.rs
+++ b/src/util.rs
@@ -120,9 +120,16 @@ pub fn get_id(object: &JsonObject) -> Result<Option<JsonValue>, Error> {
 }
 
 /// Used by Feature
-pub fn get_geometry(object: &JsonObject) -> Result<Geometry, Error> {
-    let geometry = expect_object!(expect_property!(object, "geometry", "Missing 'geometry' field"));
-    return Geometry::from_object(geometry);
+pub fn get_geometry(object: &JsonObject) -> Result<Option<Geometry>, Error> {
+    let geometry = expect_property!(object, "geometry", "Missing 'geometry' field");
+    match *geometry {
+        JsonValue::Object(ref x) => {
+            let geometry_object = try!(Geometry::from_object(x));
+            Ok(Some(geometry_object))
+        },
+        JsonValue::Null => Ok(None),
+        _ => Err(Error::FeatureInvalidGeometryValue),
+    }
 }
 
 /// Used by FeatureCollection


### PR DESCRIPTION
Fixes https://github.com/georust/rust-geojson/issues/42.