### PR TITLE
support serde 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ with-serde = ["serde","serde_json"]
 
 [dependencies]
 rustc-serialize = { version = "0.3", optional = true }
-serde = { version = "~0.7", optional = true }
-serde_json = { version = "~0.7", optional = true }
+serde = { version = "~0.8", optional = true }
+serde_json = { version = "~0.8", optional = true }

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -33,13 +33,11 @@ use ::{Bbox, Crs, Error, Feature, FromObject, util};
 ///
 /// Serialization:
 ///
-/// ```norun
+/// ```
 /// # extern crate geojson;
-/// # extern crate rustc_serialize;
 /// # fn main() {
 /// use geojson::FeatureCollection;
 /// use geojson::GeoJson;
-/// use rustc_serialize::json::ToJson;
 ///
 /// let feature_collection = FeatureCollection {
 ///     bbox: None,

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -33,7 +33,7 @@ use ::{Bbox, Crs, Error, Feature, FromObject, util};
 ///
 /// Serialization:
 ///
-/// ```rust
+/// ```norun
 /// # extern crate geojson;
 /// # extern crate rustc_serialize;
 /// # fn main() {

--- a/src/lib.rustc_serialize.rs.in
+++ b/src/lib.rustc_serialize.rs.in
@@ -6,5 +6,9 @@ mod json {
         (*val).to_json()
     }
 
+    pub fn as_str(val: &JsonValue) -> Option<&str> {
+    	val.as_string()
+    }
+
     pub use rustc_serialize::json::{ Json as JsonValue, Object as JsonObject, ToJson };
 }

--- a/src/lib.serde.rs.in
+++ b/src/lib.serde.rs.in
@@ -11,6 +11,10 @@ mod json {
         ::serde_json::value::to_value(val)
     }
 
+    pub fn as_str(val: &Value) -> Option<&str> {
+    	val.as_str()
+    }
+
     pub use serde::{ Serialize, Deserialize, Serializer, Deserializer, Error as SerdeError };
     pub use serde_json::Value as JsonValue;
     pub type JsonObject = BTreeMap<String, JsonValue>;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -20,7 +20,7 @@ macro_rules! expect_type {
 
 macro_rules! expect_string {
     ($value:expr) => (try!(
-        match $value.as_string() {
+        match $crate::json::as_str($value) {
             Some(v) => Ok(v),
             None => Err({use Error; Error::ExpectedStringValue})
         }


### PR DESCRIPTION
Add support for `serde 0.8`. There wasn't much that needed changing, but one of the doc tests was failing so I've just set it to `norun`.