### PR TITLE
Support Foreign members

### DIFF
--- a/src/feature.rs
+++ b/src/feature.rs
@@ -55,8 +55,8 @@ impl<'a> From<&'a Feature> for JsonObject {
             map.insert(String::from("id"), serde_json::to_value(id).unwrap());
         }
         if let Some(ref foreign_members) = feature.foreign_members {
-            for key in foreign_members.keys() {
-                map.insert(key.to_string(), foreign_members.get(key.as_str()).unwrap().clone());
+            for (key, value) in foreign_members {
+                map.insert(key.to_owned(), value.to_owned());
             }
         }
         return map;

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -28,6 +28,7 @@ pub struct Feature {
     pub geometry: Option<Geometry>,
     pub id: Option<JsonValue>,
     pub properties: Option<JsonObject>,
+    pub foreign_members: Option<JsonObject>
 }
 
 impl<'a> From<&'a Feature> for JsonObject {
@@ -49,7 +50,11 @@ impl<'a> From<&'a Feature> for JsonObject {
         if let Some(ref id) = feature.id {
             map.insert(String::from("id"), serde_json::to_value(id).unwrap());
         }
-
+        if let Some(ref foreign_members) = feature.foreign_members {
+            for key in foreign_members.keys() {
+                map.insert(key.to_string(), foreign_members.get(key.as_str()).unwrap().clone());
+            }
+        }
         return map;
     }
 }
@@ -62,6 +67,7 @@ impl FromObject for Feature {
             id: try!(util::get_id(object)),
             crs: try!(util::get_crs(object)),
             bbox: try!(util::get_bbox(object)),
+            foreign_members: try!(util::get_foreign_members(object, "Feature"))
         });
     }
 }
@@ -107,11 +113,13 @@ mod tests {
                 value: Value::Point(vec![1.1, 2.1]),
                 crs: None,
                 bbox: None,
+                foreign_members: None
             }),
             properties: properties(),
             crs: None,
             bbox: None,
             id: None,
+            foreign_members: None
         }
     }
 

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -37,6 +37,7 @@ use {Bbox, Crs, Error, Feature, FromObject, util};
 ///     bbox: None,
 ///     crs: None,
 ///     features: vec![],
+///     foreign_members: None,
 /// };
 ///
 /// let serialized = GeoJson::from(feature_collection).to_string();
@@ -52,6 +53,11 @@ pub struct FeatureCollection {
     pub bbox: Option<Bbox>,
     pub crs: Option<Crs>,
     pub features: Vec<Feature>,
+    /// Foreign Members
+    ///
+    /// [RFC7946 § 6]
+    /// (https://tools.ietf.org/html/rfc7946#section-6)
+    pub foreign_members: Option<JsonObject>
 }
 
 impl<'a> From<&'a FeatureCollection> for JsonObject {
@@ -69,6 +75,12 @@ impl<'a> From<&'a FeatureCollection> for JsonObject {
             map.insert(String::from("bbox"), serde_json::to_value(bbox).unwrap());
         }
 
+        if let Some(ref foreign_members) = fc.foreign_members {
+            for key in foreign_members.keys() {
+                map.insert(key.to_string(), foreign_members.get(key.as_str()).unwrap().clone());
+            }
+        }
+
         return map;
     }
 }
@@ -79,6 +91,7 @@ impl FromObject for FeatureCollection {
             bbox: try!(util::get_bbox(object)),
             features: try!(util::get_features(object)),
             crs: try!(util::get_crs(object)),
+            foreign_members: try!(util::get_foreign_members(object, "FeatureCollection"))
         });
     }
 }

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -76,8 +76,8 @@ impl<'a> From<&'a FeatureCollection> for JsonObject {
         }
 
         if let Some(ref foreign_members) = fc.foreign_members {
-            for key in foreign_members.keys() {
-                map.insert(key.to_string(), foreign_members.get(key.as_str()).unwrap().clone());
+            for (key, value) in foreign_members {
+                map.insert(key.to_owned(), value.to_owned());
             }
         }
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -95,6 +95,7 @@ pub struct Geometry {
     pub bbox: Option<Bbox>,
     pub value: Value,
     pub crs: Option<Crs>,
+    pub foreign_members: Option<JsonObject>
 }
 
 impl Geometry {
@@ -105,6 +106,7 @@ impl Geometry {
             bbox: None,
             value: value,
             crs: None,
+            foreign_members: None
         }
     }
 }
@@ -136,6 +138,11 @@ impl<'a> From<&'a Geometry> for JsonObject {
                        _ => "coordinates",
                    }),
                    ::serde_json::to_value(&geometry.value).unwrap());
+        if let Some(ref foreign_members) = geometry.foreign_members {
+            for key in foreign_members.keys() {
+                map.insert(key.to_string(), foreign_members.get(key.as_str()).unwrap().clone());
+            }
+        }
         return map;
     }
 }
@@ -156,11 +163,13 @@ impl FromObject for Geometry {
 
         let bbox = try!(util::get_bbox(object));
         let crs = try!(util::get_crs(object));
+        let foreign_members = try!(util::get_foreign_members(object, "Geometry"));
 
         return Ok(Geometry {
             bbox: bbox,
             value: value,
             crs: crs,
+            foreign_members: foreign_members
         });
     }
 }
@@ -190,6 +199,8 @@ impl<'de> Deserialize<'de> for Geometry {
 #[cfg(test)]
 mod tests {
     use {GeoJson, Geometry, Value};
+    use serde_json;
+    use json::JsonObject;
 
     fn encode(geometry: &Geometry) -> String {
         use serde_json;
@@ -208,6 +219,7 @@ mod tests {
             value: Value::Point(vec![1.1, 2.1]),
             crs: None,
             bbox: None,
+            foreign_members: None
         };
 
         // Test encode
@@ -223,14 +235,38 @@ mod tests {
     }
 
     #[test]
+    fn encode_decode_geometry_and_foreign_member() {
+        let geometry_json_str = "{\"coordinates\":[1.1,2.1],\"other_member\":\"some_value\",\"type\":\"Point\"}";
+        let mut foreign_members = JsonObject::new();
+        foreign_members.insert(String::from("other_member"), serde_json::to_value("some_value").unwrap());
+        let geometry = Geometry {
+            value: Value::Point(vec![1.1, 2.1]),
+            crs: None,
+            bbox: None,
+            foreign_members: Some(foreign_members)
+        };
+
+        // Test encode
+        let json_string = encode(&geometry);
+        assert_eq!(json_string, geometry_json_str);
+
+        // Test decode
+        let decoded_geometry = match decode(geometry_json_str.into()) {
+            GeoJson::Geometry(g) => g,
+            _ => unreachable!(),
+        };
+        assert_eq!(decoded_geometry, geometry);
+    }
+
+    #[test]
     fn encode_decode_geometry_collection() {
         let geometry_collection = Geometry {
                 bbox: None,
                 value: Value::GeometryCollection(vec![
-                    Geometry { bbox: None, value: Value::Point(vec![100.0, 0.0]), crs: None },
+                    Geometry { bbox: None, value: Value::Point(vec![100.0, 0.0]), crs: None, foreign_members: None },
                     Geometry { bbox: None, value: Value::LineString(vec![vec![101.0, 0.0], vec![102.0, 1.0]]),
-                crs: None }]),
-            crs: None };
+                crs: None, foreign_members: None }]),
+            crs: None, foreign_members: None };
 
         let geometry_collection_string = "{\"geometries\":[{\"coordinates\":[100.0,0.0],\"type\":\"Point\"},{\"coordinates\":[[101.0,0.0],[102.0,1.0]],\"type\":\"LineString\"}],\"type\":\"GeometryCollection\"}";
         // Test encode

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -95,6 +95,10 @@ pub struct Geometry {
     pub bbox: Option<Bbox>,
     pub value: Value,
     pub crs: Option<Crs>,
+    /// Foreign Members
+    ///
+    /// [RFC7946 § 6]
+    /// (https://tools.ietf.org/html/rfc7946#section-6)
     pub foreign_members: Option<JsonObject>
 }
 
@@ -199,11 +203,10 @@ impl<'de> Deserialize<'de> for Geometry {
 #[cfg(test)]
 mod tests {
     use {GeoJson, Geometry, Value};
-    use serde_json;
     use json::JsonObject;
+    use serde_json;
 
     fn encode(geometry: &Geometry) -> String {
-        use serde_json;
 
         serde_json::to_string(&geometry).unwrap()
     }
@@ -235,10 +238,10 @@ mod tests {
     }
 
     #[test]
-    fn encode_decode_geometry_and_foreign_member() {
-        let geometry_json_str = "{\"coordinates\":[1.1,2.1],\"other_member\":\"some_value\",\"type\":\"Point\"}";
+    fn encode_decode_geometry_with_foreign_member() {
+        let geometry_json_str = "{\"coordinates\":[1.1,2.1],\"other_member\":true,\"type\":\"Point\"}";
         let mut foreign_members = JsonObject::new();
-        foreign_members.insert(String::from("other_member"), serde_json::to_value("some_value").unwrap());
+        foreign_members.insert(String::from("other_member"), serde_json::to_value(true).unwrap());
         let geometry = Geometry {
             value: Value::Point(vec![1.1, 2.1]),
             crs: None,

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -143,8 +143,8 @@ impl<'a> From<&'a Geometry> for JsonObject {
                    }),
                    ::serde_json::to_value(&geometry.value).unwrap());
         if let Some(ref foreign_members) = geometry.foreign_members {
-            for key in foreign_members.keys() {
-                map.insert(key.to_string(), foreign_members.get(key.as_str()).unwrap().clone());
+            for (key, value) in foreign_members {
+                map.insert(key.to_owned(), value.to_owned());
             }
         }
         return map;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@
 //!     geometry: Some(geometry),
 //!     id: None,
 //!     properties: Some(properties),
+//!     foreign_members: None
 //! });
 //!
 //! let geojson_string = geojson.to_string();


### PR DESCRIPTION
This PR allow to encode/decode foreign members, according to the specification, and should fix #67.

As @frewsxcv suggested it's implemented as a `serde_json::Map` (using the type `geojson::json::JsonObject`) on `Geometry`, `Feature` and `FeatureCollection`.

(Waiting for more returns I left the "crs" field for now)
