### PR TITLE
Change how foreign members are parsed

### DIFF
--- a/src/feature.rs
+++ b/src/feature.rs
@@ -60,14 +60,16 @@ impl<'a> From<&'a Feature> for JsonObject {
 }
 
 impl FromObject for Feature {
-    fn from_object(object: &JsonObject) -> Result<Self, Error> {
-        return Ok(Feature {
-            geometry: try!(util::get_geometry(object)),
-            properties: try!(util::get_properties(object)),
-            id: try!(util::get_id(object)),
-            bbox: try!(util::get_bbox(object)),
-            foreign_members: try!(util::get_foreign_members(object, "Feature"))
-        });
+    fn from_object(object: &mut JsonObject) -> Result<Self, Error> {
+        match expect_type!(object) {
+            "Feature" => Ok(Feature {
+                            geometry: try!(util::get_geometry(object)),
+                            properties: try!(util::get_properties(object)),
+                            id: try!(util::get_id(object)),
+                            bbox: try!(util::get_bbox(object)),
+                            foreign_members: try!(util::get_foreign_members(object))}),
+            &_ => Err(Error::GeoJsonUnknownType)
+        }
     }
 }
 
@@ -86,9 +88,9 @@ impl<'de> Deserialize<'de> for Feature {
         use std::error::Error as StdError;
         use serde::de::Error as SerdeError;
 
-        let val = try!(JsonObject::deserialize(deserializer));
+        let mut val = try!(JsonObject::deserialize(deserializer));
 
-        Feature::from_object(&val).map_err(|e| D::Error::custom(e.description()))
+        Feature::from_object(&mut val).map_err(|e| D::Error::custom(e.description()))
     }
 }
 

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -173,6 +173,33 @@ mod tests {
     }
 
     #[test]
+    fn encode_decode_feature_with_id() {
+        use serde_json;
+        let feature_json_str = "{\"geometry\":{\"coordinates\":[1.1,2.1],\"type\":\"Point\"},\"id\":0,\"properties\":{},\"type\":\"Feature\"}";
+        let feature = ::Feature {
+            geometry: Some(Geometry {
+                value: Value::Point(vec![1.1, 2.1]),
+                bbox: None,
+                foreign_members: None
+            }),
+            properties: properties(),
+            bbox: None,
+            id: Some(serde_json::to_value(0).unwrap()),
+            foreign_members: None
+        };
+        // Test encode
+        let json_string = encode(&feature);
+        assert_eq!(json_string, feature_json_str);
+
+        // Test decode
+        let decoded_feature = match decode(feature_json_str.into()) {
+            GeoJson::Feature(f) => f,
+            _ => unreachable!(),
+        };
+        assert_eq!(decoded_feature, feature);
+    }
+
+    #[test]
     fn encode_decode_feature_with_foreign_member() {
         use serde_json;
         use ::json::JsonObject;

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -60,14 +60,14 @@ impl<'a> From<&'a Feature> for JsonObject {
 }
 
 impl FromObject for Feature {
-    fn from_object(object: &mut JsonObject) -> Result<Self, Error> {
+    fn from_object(mut object: JsonObject) -> Result<Self, Error> {
         match expect_type!(object) {
             "Feature" => Ok(Feature {
-                            geometry: try!(util::get_geometry(object)),
-                            properties: try!(util::get_properties(object)),
-                            id: try!(util::get_id(object)),
-                            bbox: try!(util::get_bbox(object)),
-                            foreign_members: try!(util::get_foreign_members(object))}),
+                            geometry: try!(util::get_geometry(&mut object)),
+                            properties: try!(util::get_properties(&mut object)),
+                            id: try!(util::get_id(&mut object)),
+                            bbox: try!(util::get_bbox(&mut object)),
+                            foreign_members: try!(util::get_foreign_members(&mut object))}),
             &_ => Err(Error::GeoJsonUnknownType)
         }
     }
@@ -88,9 +88,9 @@ impl<'de> Deserialize<'de> for Feature {
         use std::error::Error as StdError;
         use serde::de::Error as SerdeError;
 
-        let mut val = try!(JsonObject::deserialize(deserializer));
+        let val = try!(JsonObject::deserialize(deserializer));
 
-        Feature::from_object(&mut val).map_err(|e| D::Error::custom(e.description()))
+        Feature::from_object(val).map_err(|e| D::Error::custom(e.description()))
     }
 }
 

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -80,12 +80,14 @@ impl<'a> From<&'a FeatureCollection> for JsonObject {
 }
 
 impl FromObject for FeatureCollection {
-    fn from_object(object: &JsonObject) -> Result<Self, Error> {
-        return Ok(FeatureCollection {
-            bbox: try!(util::get_bbox(object)),
-            features: try!(util::get_features(object)),
-            foreign_members: try!(util::get_foreign_members(object, "FeatureCollection"))
-        });
+    fn from_object(object: &mut JsonObject) -> Result<Self, Error> {
+        match expect_type!(object) {
+            "FeatureCollection" => Ok(FeatureCollection {
+                    bbox: try!(util::get_bbox(object)),
+                    features: try!(util::get_features(object)),
+                    foreign_members: try!(util::get_foreign_members(object)) }),
+            &_ => Err(Error::ExpectedProperty)
+        }
     }
 }
 
@@ -104,8 +106,8 @@ impl<'de> Deserialize<'de> for FeatureCollection {
         use std::error::Error as StdError;
         use serde::de::Error as SerdeError;
 
-        let val = try!(JsonObject::deserialize(deserializer));
+        let mut val = try!(JsonObject::deserialize(deserializer));
 
-        FeatureCollection::from_object(&val).map_err(|e| D::Error::custom(e.description()))
+        FeatureCollection::from_object(&mut val).map_err(|e| D::Error::custom(e.description()))
     }
 }

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -80,12 +80,12 @@ impl<'a> From<&'a FeatureCollection> for JsonObject {
 }
 
 impl FromObject for FeatureCollection {
-    fn from_object(object: &mut JsonObject) -> Result<Self, Error> {
+    fn from_object(mut object: JsonObject) -> Result<Self, Error> {
         match expect_type!(object) {
             "FeatureCollection" => Ok(FeatureCollection {
-                    bbox: try!(util::get_bbox(object)),
-                    features: try!(util::get_features(object)),
-                    foreign_members: try!(util::get_foreign_members(object)) }),
+                    bbox: try!(util::get_bbox(&mut object)),
+                    features: try!(util::get_features(&mut object)),
+                    foreign_members: try!(util::get_foreign_members(&mut object)) }),
             &_ => Err(Error::ExpectedProperty)
         }
     }
@@ -106,8 +106,8 @@ impl<'de> Deserialize<'de> for FeatureCollection {
         use std::error::Error as StdError;
         use serde::de::Error as SerdeError;
 
-        let mut val = try!(JsonObject::deserialize(deserializer));
+        let val = try!(JsonObject::deserialize(deserializer));
 
-        FeatureCollection::from_object(&mut val).map_err(|e| D::Error::custom(e.description()))
+        FeatureCollection::from_object(val).map_err(|e| D::Error::custom(e.description()))
     }
 }

--- a/src/geojson.rs
+++ b/src/geojson.rs
@@ -61,9 +61,9 @@ impl From<FeatureCollection> for GeoJson {
 
 
 impl FromObject for GeoJson {
-    fn from_object(object: &mut JsonObject) -> Result<Self, Error> {
+    fn from_object(object: JsonObject) -> Result<Self, Error> {
         let _type = match object.get("type") {
-            Some(t) => t,
+            Some(ref mut t) => t.clone(),
             None => return Err(Error::ExpectedProperty)
 
         };
@@ -74,10 +74,10 @@ impl FromObject for GeoJson {
             "MultiLineString" |
             "Polygon" |
             "MultiPolygon" |
-            "GeometryCollection" => Geometry::from_object(&mut object.to_owned()).map(GeoJson::Geometry),
-            "Feature" => Feature::from_object(&mut object.to_owned()).map(GeoJson::Feature),
+            "GeometryCollection" => Geometry::from_object(object).map(GeoJson::Geometry),
+            "Feature" => Feature::from_object(object).map(GeoJson::Feature),
             "FeatureCollection" => {
-                FeatureCollection::from_object(&mut object.to_owned()).map(GeoJson::FeatureCollection)
+                FeatureCollection::from_object(object).map(GeoJson::FeatureCollection)
             }
             _ => Err(Error::GeoJsonUnknownType),
         };
@@ -99,9 +99,9 @@ impl<'de> Deserialize<'de> for GeoJson {
         use std::error::Error as StdError;
         use serde::de::Error as SerdeError;
 
-        let mut val = try!(JsonObject::deserialize(deserializer));
+        let val = try!(JsonObject::deserialize(deserializer));
 
-        GeoJson::from_object(&mut val).map_err(|e| D::Error::custom(e.description()))
+        GeoJson::from_object(val).map_err(|e| D::Error::custom(e.description()))
     }
 }
 
@@ -111,7 +111,7 @@ impl FromStr for GeoJson {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let object = try!(get_object(s));
 
-        return GeoJson::from_object(&mut object.into());
+        return GeoJson::from_object(object);
     }
 }
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -147,9 +147,8 @@ impl<'a> From<&'a Geometry> for JsonObject {
 }
 
 impl FromObject for Geometry {
-    fn from_object(object: &JsonObject) -> Result<Self, Error> {
-        let type_ = expect_type!(object);
-        let value = match type_ {
+    fn from_object(object: &mut JsonObject) -> Result<Self, Error> {
+        let value = match expect_type!(object) {
             "Point" => Value::Point(try!(util::get_coords_one_pos(object))),
             "MultiPoint" => Value::MultiPoint(try!(util::get_coords_1d_pos(object))),
             "LineString" => Value::LineString(try!(util::get_coords_1d_pos(object))),
@@ -159,10 +158,8 @@ impl FromObject for Geometry {
             "GeometryCollection" => Value::GeometryCollection(try!(util::get_geometries(object))),
             _ => return Err(Error::GeometryUnknownType),
         };
-
         let bbox = try!(util::get_bbox(object));
-        let foreign_members = try!(util::get_foreign_members(object, "Geometry"));
-
+        let foreign_members = try!(util::get_foreign_members(object));
         return Ok(Geometry {
             bbox: bbox,
             value: value,
@@ -186,9 +183,9 @@ impl<'de> Deserialize<'de> for Geometry {
         use std::error::Error as StdError;
         use serde::de::Error as SerdeError;
 
-        let val = try!(JsonObject::deserialize(deserializer));
+        let mut val = try!(JsonObject::deserialize(deserializer));
 
-        Geometry::from_object(&val).map_err(|e| D::Error::custom(e.description()))
+        Geometry::from_object(&mut val).map_err(|e| D::Error::custom(e.description()))
     }
 }
 

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -147,19 +147,19 @@ impl<'a> From<&'a Geometry> for JsonObject {
 }
 
 impl FromObject for Geometry {
-    fn from_object(object: &mut JsonObject) -> Result<Self, Error> {
+    fn from_object(mut object: JsonObject) -> Result<Self, Error> {
         let value = match expect_type!(object) {
-            "Point" => Value::Point(try!(util::get_coords_one_pos(object))),
-            "MultiPoint" => Value::MultiPoint(try!(util::get_coords_1d_pos(object))),
-            "LineString" => Value::LineString(try!(util::get_coords_1d_pos(object))),
-            "MultiLineString" => Value::MultiLineString(try!(util::get_coords_2d_pos(object))),
-            "Polygon" => Value::Polygon(try!(util::get_coords_2d_pos(object))),
-            "MultiPolygon" => Value::MultiPolygon(try!(util::get_coords_3d_pos(object))),
-            "GeometryCollection" => Value::GeometryCollection(try!(util::get_geometries(object))),
+            "Point" => Value::Point(try!(util::get_coords_one_pos(&mut object))),
+            "MultiPoint" => Value::MultiPoint(try!(util::get_coords_1d_pos(&mut object))),
+            "LineString" => Value::LineString(try!(util::get_coords_1d_pos(&mut object))),
+            "MultiLineString" => Value::MultiLineString(try!(util::get_coords_2d_pos(&mut object))),
+            "Polygon" => Value::Polygon(try!(util::get_coords_2d_pos(&mut object))),
+            "MultiPolygon" => Value::MultiPolygon(try!(util::get_coords_3d_pos(&mut object))),
+            "GeometryCollection" => Value::GeometryCollection(try!(util::get_geometries(&mut object))),
             _ => return Err(Error::GeometryUnknownType),
         };
-        let bbox = try!(util::get_bbox(object));
-        let foreign_members = try!(util::get_foreign_members(object));
+        let bbox = try!(util::get_bbox(&mut object));
+        let foreign_members = try!(util::get_foreign_members(&mut object));
         return Ok(Geometry {
             bbox: bbox,
             value: value,
@@ -183,9 +183,9 @@ impl<'de> Deserialize<'de> for Geometry {
         use std::error::Error as StdError;
         use serde::de::Error as SerdeError;
 
-        let mut val = try!(JsonObject::deserialize(deserializer));
+        let val = try!(JsonObject::deserialize(deserializer));
 
-        Geometry::from_object(&mut val).map_err(|e| D::Error::custom(e.description()))
+        Geometry::from_object(val).map_err(|e| D::Error::custom(e.description()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,5 +233,5 @@ mod json {
 }
 
 trait FromObject: Sized {
-    fn from_object(object: &json::JsonObject) -> Result<Self, Error>;
+    fn from_object(object: &mut json::JsonObject) -> Result<Self, Error>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,5 +233,5 @@ mod json {
 }
 
 trait FromObject: Sized {
-    fn from_object(object: &mut json::JsonObject) -> Result<Self, Error>;
+    fn from_object(object: json::JsonObject) -> Result<Self, Error>;
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -56,7 +56,7 @@ macro_rules! expect_object {
 
 macro_rules! expect_property {
     ($obj:expr, $name:expr, $desc:expr) => (
-        match $obj.get($name) {
+        match $obj.remove($name) {
             Some(v) => v,
             None => return Err({use Error; Error::ExpectedProperty}),
         };

--- a/src/util.rs
+++ b/src/util.rs
@@ -108,7 +108,7 @@ pub fn get_geometries(object: &mut JsonObject) -> Result<Vec<Geometry>, Error> {
     let mut geometries = vec![];
     for json in geometries_array {
         let obj = expect_object!(json);
-        let geometry = try!(Geometry::from_object(&mut obj.to_owned()));
+        let geometry = try!(Geometry::from_object(obj.clone()));
         geometries.push(geometry);
     }
     return Ok(geometries);
@@ -123,8 +123,8 @@ pub fn get_id(object: &mut JsonObject) -> Result<Option<JsonValue>, Error> {
 pub fn get_geometry(object: &mut JsonObject) -> Result<Option<Geometry>, Error> {
     let geometry = expect_property!(object, "geometry", "Missing 'geometry' field");
     match geometry {
-        JsonValue::Object(ref x) => {
-            let geometry_object = try!(Geometry::from_object(&mut x.to_owned()));
+        JsonValue::Object(x) => {
+            let geometry_object = try!(Geometry::from_object(x));
             Ok(Some(geometry_object))
         }
         JsonValue::Null => Ok(None),
@@ -139,7 +139,7 @@ pub fn get_features(object: &mut JsonObject) -> Result<Vec<Feature>, Error> {
     let features_json = expect_array!(prop);
     for feature in features_json {
         let feature = expect_object!(feature);
-        let feature: Feature = try!(Feature::from_object(&mut feature.to_owned()));
+        let feature: Feature = try!(Feature::from_object(feature.clone()));
         features.push(feature);
     }
     return Ok(features);


### PR DESCRIPTION
I found the issue #75 while working on #73 .

Basically this PR removes the logic which was introduced previously for reading `foreign_members` by progressively removing the various element of each `FeatureCollection`, `Feature` and `Geometry` but i couldn't get ride of some `clone()` calls due to the nature of the value returned by the method `serde_json::Map::as_object()` (i would be glad to receive advice on this point if any).

So this PR fixes #75 and seems to already improve performances when doing the parsing operations (probably by avoiding the various `HashSet` creations) but I feel like their is still room for improvement regarding the issue #73 ..
