### PR TITLE
Replace link to generated documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["Corey Farwell <coreyf@rwell.org>",
 license = "MIT/Apache-2.0"
 repository = "https://github.com/georust/rust-geojson"
 readme = "README.md"
-documentation = "https://georust.github.io/rust-geojson/"
 keywords = ["geojson", "gis", "json", "geo"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Corey Farwell <coreyf@rwell.org>",
 license = "MIT/Apache-2.0"
 repository = "https://github.com/georust/rust-geojson"
 readme = "README.md"
+documentation = "https://docs.rs/geojson/"
 keywords = ["geojson", "gis", "json", "geo"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ rust-geojson
 [![Build Status](https://travis-ci.org/georust/rust-geojson.svg)](https://travis-ci.org/georust/rust-geojson)
 [![geojson on Crates.io](https://meritbadge.herokuapp.com/geojson)](https://crates.io/crates/geojson)
 
-[Documentation](https://georust.github.io/rust-geojson/)
+[Documentation](https://docs.rs/geojson/)
 
 Library for serializing the [GeoJSON](http://geojson.org) vector GIS file format
 


### PR DESCRIPTION
This PR is about removing references to the outdated documentation (hosted on github.io) in favor of docs.rs documentation (so it addresses #78 ).
It changes the link to the documentation in the `README.md` file and removes the `documentation` key in the `Cargo.toml` file (once removed I guess on the next release the documentation link on [crates.io](https://crates.io/crates/geojson) will point automatically on [docs.rs](https://docs.rs/geojson/) but now it use that entry in the Cargo.toml file).

I guess the priority level of this PR is very low, but I found it disturbing to find only these references to the old documentation!