### PR TITLE
Deserialize Optimizations

### DIFF
--- a/src/geojson.rs
+++ b/src/geojson.rs
@@ -121,8 +121,8 @@ fn get_object(s: &str) -> Result<JsonObject, Error> {
         Err(..) => return Err(Error::MalformedJson),
     };
 
-    if let Some(geo) = decoded_json.as_object() {
-        return Ok(geo.clone());
+    if let ::serde_json::Value::Object(geo) = decoded_json {
+        return Ok(geo);
     } else {
         return Err(Error::MalformedJson);
     }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -62,3 +62,21 @@ macro_rules! expect_property {
         };
     )
 }
+
+macro_rules! expect_owned_array {
+    ($value:expr) => (try!(
+        match $value {
+            JsonValue::Array(v) => Ok(v),
+            _ => Err({use Error; Error::ExpectedArrayValue})
+        }
+    ))
+}
+
+macro_rules! expect_owned_object {
+    ($value:expr) => (try!(
+        match $value {
+            JsonValue::Object(o) => Ok(o),
+            _ => Err({use Error; Error::ExpectedObjectValue})
+        }
+    ))
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -135,11 +135,11 @@ pub fn get_geometry(object: &mut JsonObject) -> Result<Option<Geometry>, Error> 
 /// Used by FeatureCollection
 pub fn get_features(object: &mut JsonObject) -> Result<Vec<Feature>, Error> {
     let prop = expect_property!(object, "features", "Missing 'features' field");
-    let features_json = expect_array!(prop);
+    let features_json = expect_owned_array!(prop);
     let mut features = Vec::with_capacity(features_json.len());
     for feature in features_json {
-        let feature = expect_object!(feature);
-        let feature: Feature = try!(Feature::from_object(feature.clone()));
+        let feature = expect_owned_object!(feature);
+        let feature: Feature = try!(Feature::from_object(feature));
         features.push(feature);
     }
     return Ok(features);

--- a/src/util.rs
+++ b/src/util.rs
@@ -134,9 +134,9 @@ pub fn get_geometry(object: &mut JsonObject) -> Result<Option<Geometry>, Error> 
 
 /// Used by FeatureCollection
 pub fn get_features(object: &mut JsonObject) -> Result<Vec<Feature>, Error> {
-    let mut features = vec![];
     let prop = expect_property!(object, "features", "Missing 'features' field");
     let features_json = expect_array!(prop);
+    let mut features = Vec::with_capacity(features_json.len());
     for feature in features_json {
         let feature = expect_object!(feature);
         let feature: Feature = try!(Feature::from_object(feature.clone()));
@@ -148,7 +148,7 @@ pub fn get_features(object: &mut JsonObject) -> Result<Vec<Feature>, Error> {
 
 fn json_to_position(json: &JsonValue) -> Result<Position, Error> {
     let coords_array = expect_array!(json);
-    let mut coords = vec![];
+    let mut coords = Vec::with_capacity(coords_array.len());
     for position in coords_array {
         coords.push(expect_f64!(position));
     }
@@ -157,7 +157,7 @@ fn json_to_position(json: &JsonValue) -> Result<Position, Error> {
 
 fn json_to_1d_positions(json: &JsonValue) -> Result<Vec<Position>, Error> {
     let coords_array = expect_array!(json);
-    let mut coords = vec![];
+    let mut coords = Vec::with_capacity(coords_array.len());
     for item in coords_array {
         coords.push(try!(json_to_position(item)));
     }
@@ -166,7 +166,7 @@ fn json_to_1d_positions(json: &JsonValue) -> Result<Vec<Position>, Error> {
 
 fn json_to_2d_positions(json: &JsonValue) -> Result<Vec<Vec<Position>>, Error> {
     let coords_array = expect_array!(json);
-    let mut coords = vec![];
+    let mut coords = Vec::with_capacity(coords_array.len());
     for item in coords_array {
         coords.push(try!(json_to_1d_positions(item)));
     }
@@ -175,7 +175,7 @@ fn json_to_2d_positions(json: &JsonValue) -> Result<Vec<Vec<Position>>, Error> {
 
 fn json_to_3d_positions(json: &JsonValue) -> Result<Vec<Vec<Vec<Position>>>, Error> {
     let coords_array = expect_array!(json);
-    let mut coords = vec![];
+    let mut coords = Vec::with_capacity(coords_array.len());
     for item in coords_array {
         coords.push(try!(json_to_2d_positions(item)));
     }


### PR DESCRIPTION
Hello, this PR has a couple of parsing optimizations in two commits:
- When creating `Vec`s for GeoJSON objects, initialize with `Vec::with_capacity(...)` since we know what size to expect.
- Avoid a couple of critical `clone()` calls.

Currently, when parsing from a string, the entire JSON value is cloned after it's parsed, then each Feature is cloned again when parsing a FeatureCollection. I believe this is due to serde_json's `as_array()` and `as_object()` functions returning borrowed references. I avoid those calls by doing the `match` directly (by adding the `_owned` macros), which allows moving those objects without cloning.

I tested this on a release target on a ~330MB GeoJSON file (all Polygons), current master parses in about 18 seconds. After these changes, it takes under 10s. Parsing using just serde_json is about 8.2 s.

I'm pretty new to Rust so feel free to let me know if these changes are a bad idea -- or any other suggestions.

