### PR TITLE
Expand docs with parsing examples and corner cases, and enable conversion docs

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -122,6 +122,7 @@ fn create_geo_multi_polygon<T>(multi_polygon_type: &Vec<PolygonType>) -> geo::Mu
         .collect())
 }
 
+/// This trait provides fallible conversions from GeoJSON values to [Geo](https://docs.rs/geo) types
 pub trait TryInto<T> {
     type Err;
     fn try_into(self) -> Result<T, Self::Err>;

--- a/src/feature.rs
+++ b/src/feature.rs
@@ -43,6 +43,9 @@ impl<'a> From<&'a Feature> for JsonObject {
         if let Some(ref properties) = feature.properties {
             map.insert(String::from("properties"),
                        serde_json::to_value(properties).unwrap());
+        } else {
+            map.insert(String::from("properties"),
+                serde_json::to_value(Some(serde_json::Map::new())).unwrap());
         }
         if let Some(ref bbox) = feature.bbox {
             map.insert(String::from("bbox"), serde_json::to_value(bbox).unwrap());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@
 //!
 //! ## Conversion to Geo objects
 //!
-//! The [try_into](file:///Users/sth/dev/rust-geojson/target/doc/geojson/conversion/index.html) trait provides *fallible* conversions from GeoJSON Value structs
+//! The [try_into](conversion/trait.TryInto.html) trait provides *fallible* conversions from GeoJSON Value structs
 //! to [Geo](https://docs.rs/geo) types, allowing them to be measured or used in calculations. Note that
 //! this conversion consumes the GeoJSON object, so you will not be able to match
 //! by reference as in the example above. The [polylabel_cmd](https://github.com/urschrei/polylabel_cmd/blob/master/src/main.rs) crate contains an

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,7 @@
 //! to [Geo](https://docs.rs/geo) types, allowing them to be measured or used in calculations. Note that
 //! this conversion consumes the GeoJSON object, so you will not be able to match
 //! by reference as in the example above. The [polylabel_cmd](https://github.com/urschrei/polylabel_cmd/blob/master/src/main.rs) crate contains an
-//! implementation which may be useful if you wish to perfom these conversions.
+//! implementation which may be useful if you wish to perform these conversions.
 
 
 extern crate serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,92 @@
 //! let geojson_string = geojson.to_string();
 //! # }
 //! ```
+//!
+//! ## Parsing
+//! 
+//! GeoJSON's [spec](https://tools.ietf.org/html/rfc7946) is quite simple, but
+//! it has several subtleties that must be taken into account when parsing it:  
+//! 
+//! - The `geometry` field of a `Feature` is an `Option`
+//! - `GeometryCollection`s contain other `Geometry` objects, and can nest.
+//!
+//! Here's a minimal example which will parse valid GeoJSON without taking
+//! ownership of it.
+//!
+//! ```rust
+//! use geojson::{GeoJson, Geometry, Value};
+//! 
+//! /// Process GeoJSON geometries  
+//! fn match_geometry(geom: &Geometry) {
+//!     match &geom.value {
+//!         &Value::Polygon(_) => println!("Matched a Polygon"),
+//!         &Value::MultiPolygon(_) => println!("Matched a MultiPolygon"),
+//!         &Value::GeometryCollection(ref gc) => {
+//!             println!("Matched a GeometryCollection");
+//!             // GeometryCollections contain other Geometry types, and can nest
+//!             // we deal with this by recursively processing each geometry
+//!             for geometry in gc {
+//!                 match_geometry(geometry)
+//!             }
+//!         }
+//!         // Point, LineString, and their Multi– counterparts
+//!         _ => println!("Matched some other geometry"),
+//!     }
+//! }
+//! 
+//! /// Process top-level GeoJSON items
+//! fn process_geojson(gj: &GeoJson) {
+//!     match gj {
+//!         &GeoJson::FeatureCollection(ref ctn) => for feature in &ctn.features {
+//!             if let &Some(ref geom) = &feature.geometry {
+//!                 match_geometry(&geom)
+//!             }
+//!         },
+//!         &GeoJson::Feature(ref feature) => {
+//!             if let &Some(ref geom) = &feature.geometry {
+//!                 match_geometry(&geom)
+//!             }
+//!         }
+//!         &GeoJson::Geometry(ref geometry) => match_geometry(&geometry),
+//!     }
+//! }
+//! 
+//! fn main() {
+//!     let geojson_str = r#"
+//!     {
+//!       "type": "GeometryCollection",
+//!       "geometries": [
+//!         {"type": "Point", "coordinates": [0,1]},
+//!         {"type": "MultiPoint", "coordinates": [[-1,0],[1,0]]},
+//!         {"type": "LineString", "coordinates": [[-1,-1],[1,-1]]},
+//!         {"type": "MultiLineString", "coordinates": [
+//!           [[-2,-2],[2,-2]],
+//!           [[-3,-3],[3,-3]]
+//!         ]},
+//!         {"type": "Polygon", "coordinates": [
+//!           [[-5,-5],[5,-5],[0,5],[-5,-5]],
+//!           [[-4,-4],[4,-4],[0,4],[-4,-4]]
+//!         ]},
+//!         { "type": "MultiPolygon", "coordinates": [[
+//!           [[-7,-7],[7,-7],[0,7],[-7,-7]],
+//!           [[-6,-6],[6,-6],[0,6],[-6,-6]]
+//!         ],[
+//!           [[-9,-9],[9,-9],[0,9],[-9,-9]],
+//!           [[-8,-8],[8,-8],[0,8],[-8,-8]]]
+//!         ]},
+//!         {"type": "GeometryCollection", "geometries": [
+//!           {"type": "Polygon", "coordinates": [
+//!             [[-5.5,-5.5],[5,-5],[0,5],[-5,-5]],
+//!             [[-4,-4],[4,-4],[0,4],[-4.5,-4.5]]
+//!           ]}
+//!         ]}
+//!       ]
+//!     }
+//!     "#;
+//!     let geojson = geojson_str.parse::<GeoJson>().unwrap();
+//!     process_geojson(&geojson);
+//! }
+//! ```
 
 extern crate serde;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,15 @@
 //!     process_geojson(&geojson);
 //! }
 //! ```
+//!
+//! ## Conversion to Geo objects
+//!
+//! The [try_into](file:///Users/sth/dev/rust-geojson/target/doc/geojson/conversion/index.html) trait provides *fallible* conversions from GeoJSON Value structs
+//! to [Geo](https://docs.rs/geo) types, allowing them to be measured or used in calculations. Note that
+//! this conversion consumes the GeoJSON object, so you will not be able to match
+//! by reference as in the example above. The [polylabel_cmd](https://github.com/urschrei/polylabel_cmd/blob/master/src/main.rs) crate contains an
+//! implementation which may be useful if you wish to perfom these conversions.
+
 
 extern crate serde;
 #[macro_use]
@@ -222,8 +231,7 @@ pub use feature::Feature;
 mod feature_collection;
 pub use feature_collection::FeatureCollection;
 
-/// Convert geo::types to geometry::Geometry
-#[doc(hidden)]
+/// Convert Geometries into [Geo](https://docs.rs/geo) types
 pub mod conversion;
 
 /// Error when reading a GeoJSON object from a str or Object

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,12 +110,12 @@
 //! ```rust
 //! use geojson::{GeoJson, Geometry, Value};
 //! 
-//! /// Process GeoJSON geometries  
+//! /// Process GeoJSON geometries
 //! fn match_geometry(geom: &Geometry) {
-//!     match &geom.value {
-//!         &Value::Polygon(_) => println!("Matched a Polygon"),
-//!         &Value::MultiPolygon(_) => println!("Matched a MultiPolygon"),
-//!         &Value::GeometryCollection(ref gc) => {
+//!     match geom.value {
+//!         Value::Polygon(_) => println!("Matched a Polygon"),
+//!         Value::MultiPolygon(_) => println!("Matched a MultiPolygon"),
+//!         Value::GeometryCollection(ref gc) => {
 //!             println!("Matched a GeometryCollection");
 //!             // GeometryCollections contain other Geometry types, and can nest
 //!             // we deal with this by recursively processing each geometry
@@ -130,18 +130,18 @@
 //! 
 //! /// Process top-level GeoJSON items
 //! fn process_geojson(gj: &GeoJson) {
-//!     match gj {
-//!         &GeoJson::FeatureCollection(ref ctn) => for feature in &ctn.features {
-//!             if let &Some(ref geom) = &feature.geometry {
-//!                 match_geometry(&geom)
+//!     match *gj {
+//!         GeoJson::FeatureCollection(ref ctn) => for feature in &ctn.features {
+//!             if let Some(ref geom) = feature.geometry {
+//!                 match_geometry(geom)
 //!             }
 //!         },
-//!         &GeoJson::Feature(ref feature) => {
-//!             if let &Some(ref geom) = &feature.geometry {
-//!                 match_geometry(&geom)
+//!         GeoJson::Feature(ref feature) => {
+//!             if let Some(ref geom) = feature.geometry {
+//!                 match_geometry(geom)
 //!             }
 //!         }
-//!         &GeoJson::Geometry(ref geometry) => match_geometry(&geometry),
+//!         GeoJson::Geometry(ref geometry) => match_geometry(geometry),
 //!     }
 //! }
 //! 


### PR DESCRIPTION
This also inserts a blank `properties` map when serialising, if the field was set to `None`. See https://github.com/georust/rust-geojson/pull/85/commits/b51f9934d7cdc6b98add193b5191e4285fd5a8b5