### PR TITLE
Update GeoJSON spec links to point to published standard

### DIFF
--- a/src/feature.rs
+++ b/src/feature.rs
@@ -19,8 +19,8 @@ use {Bbox, Error, FromObject, Geometry, util};
 
 /// Feature Objects
 ///
-/// [GeoJSON Format Specification § 2.2]
-/// (http://geojson.org/geojson-spec.html#feature-objects)
+/// [GeoJSON Format Specification § 3.2]
+/// (https://tools.ietf.org/html/rfc7946#section-3.2)
 #[derive(Clone, Debug, PartialEq)]
 pub struct Feature {
     pub bbox: Option<Bbox>,

--- a/src/feature_collection.rs
+++ b/src/feature_collection.rs
@@ -20,8 +20,8 @@ use {Bbox, Error, Feature, FromObject, util};
 
 /// Feature Collection Objects
 ///
-/// [GeoJSON Format Specification § 2.3]
-/// (http://geojson.org/geojson-spec.html#feature-collection-objects)
+/// [GeoJSON Format Specification § 3.3]
+/// (https://tools.ietf.org/html/rfc7946#section-3.3)
 ///
 /// # Examples
 ///

--- a/src/geojson.rs
+++ b/src/geojson.rs
@@ -22,8 +22,8 @@ use {Error, Geometry, Feature, FeatureCollection, FromObject};
 
 /// GeoJSON Objects
 ///
-/// [GeoJSON Format Specification § 2]
-/// (http://geojson.org/geojson-spec.html#geojson-objects)
+/// [GeoJSON Format Specification § 3]
+/// (https://tools.ietf.org/html/rfc7946#section-3)
 #[derive(Clone, Debug, PartialEq)]
 pub enum GeoJson {
     Geometry(Geometry),

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -22,44 +22,44 @@ use {Bbox, Error, LineStringType, PointType, PolygonType, FromObject, util};
 pub enum Value {
     /// Point
     ///
-    /// [GeoJSON Format Specification § 2.1.2]
-    /// (http://geojson.org/geojson-spec.html#point)
+    /// [GeoJSON Format Specification § 3.1.2]
+    /// (https://tools.ietf.org/html/rfc7946#section-3.1.2
     Point(PointType),
 
     /// MultiPoint
     ///
-    /// [GeoJSON Format Specification § 2.1.3]
-    /// (http://geojson.org/geojson-spec.html#multipoint)
+    /// [GeoJSON Format Specification § 3.1.3]
+    /// (https://tools.ietf.org/html/rfc7946#section-3.1.3
     MultiPoint(Vec<PointType>),
 
     /// LineString
     ///
-    /// [GeoJSON Format Specification § 2.1.4]
-    /// (http://geojson.org/geojson-spec.html#linestring)
+    /// [GeoJSON Format Specification § 3.1.4]
+    /// (https://tools.ietf.org/html/rfc7946#section-3.1.4
     LineString(LineStringType),
 
     /// MultiLineString
     ///
-    /// [GeoJSON Format Specification § 2.1.5]
-    /// (http://geojson.org/geojson-spec.html#multilinestring)
+    /// [GeoJSON Format Specification § 3.1.5]
+    /// (https://tools.ietf.org/html/rfc7946#section-3.1.5)
     MultiLineString(Vec<LineStringType>),
 
     /// Polygon
     ///
-    /// [GeoJSON Format Specification § 2.1.6]
-    /// (http://geojson.org/geojson-spec.html#polygon)
+    /// [GeoJSON Format Specification § 3.1.6]
+    /// (https://tools.ietf.org/html/rfc7946#section-3.1.6)
     Polygon(PolygonType),
 
     /// MultiPolygon
     ///
-    /// [GeoJSON Format Specification § 2.1.7]
-    /// (http://geojson.org/geojson-spec.html#multipolygon)
+    /// [GeoJSON Format Specification § 3.1.7]
+    /// (https://tools.ietf.org/html/rfc7946#section-3.1.7)
     MultiPolygon(Vec<PolygonType>),
 
     /// GeometryCollection
     ///
-    /// [GeoJSON Format Specification § 2.1.8]
-    /// (http://geojson.org/geojson-spec.html#geometry-collection)
+    /// [GeoJSON Format Specification § 3.1.8]
+    /// (https://tools.ietf.org/html/rfc7946#section-3.1.8)
     GeometryCollection(Vec<Geometry>),
 }
 
@@ -88,8 +88,8 @@ impl Serialize for Value {
 
 /// Geometry Objects
 ///
-/// [GeoJSON Format Specification § 2.1]
-/// (http://geojson.org/geojson-spec.html#geometry-objects)
+/// [GeoJSON Format Specification § 3.1]
+/// (https://tools.ietf.org/html/rfc7946#section-3.1)
 #[derive(Clone, Debug, PartialEq)]
 pub struct Geometry {
     pub bbox: Option<Bbox>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,14 +200,14 @@ extern crate num_traits;
 
 /// Bounding Boxes
 ///
-/// [GeoJSON Format Specification § 4]
-/// (http://geojson.org/geojson-spec.html#bounding-boxes)
+/// [GeoJSON Format Specification § 5]
+/// (https://tools.ietf.org/html/rfc7946#section-5)
 pub type Bbox = Vec<f64>;
 
 /// Positions
 ///
-/// [GeoJSON Format Specification § 2.1.1]
-/// (http://geojson.org/geojson-spec.html#positions)
+/// [GeoJSON Format Specification § 3.1.1]
+/// (https://tools.ietf.org/html/rfc7946#section-3.1.1)
 pub type Position = Vec<f64>;
 
 pub type PointType = Position;


### PR DESCRIPTION
The spec at http://geojson.org/geojson-spec is considered obsolete,
having been replaced by IETF RFC 7946 at
https://tools.ietf.org/html/rfc7946. This commit updates all links to point to the published standard.