### PR TITLE
 Don't inject empty interior rings when converting to geo Polygons 

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -673,7 +673,7 @@ mod tests {
     }
 
     #[test]
-    fn geoson_point_conversion_test() {
+    fn geojson_point_conversion_test() {
         let coords = vec![100.0, 0.2];
         let geojson_point = Value::Point(coords.clone());
         let geo_point: geo_types::Point<f64> = geojson_point.try_into().unwrap();
@@ -683,7 +683,7 @@ mod tests {
     }
 
     #[test]
-    fn geoson_multi_point_conversion_test() {
+    fn geojson_multi_point_conversion_test() {
         let coord1 = vec![100.0, 0.2];
         let coord2 = vec![101.0, 1.0];
         let geojson_multi_point = Value::MultiPoint(vec![coord1.clone(), coord2.clone()]);
@@ -696,7 +696,7 @@ mod tests {
     }
 
     #[test]
-    fn geoson_line_string_conversion_test() {
+    fn geojson_line_string_conversion_test() {
         let coord1 = vec![100.0, 0.2];
         let coord2 = vec![101.0, 1.0];
         let geojson_line_string = Value::LineString(vec![coord1.clone(), coord2.clone()]);
@@ -709,7 +709,7 @@ mod tests {
     }
 
     #[test]
-    fn geoson_multi_line_string_conversion_test() {
+    fn geojson_multi_line_string_conversion_test() {
         let coord1 = vec![100.0, 0.2];
         let coord2 = vec![101.0, 1.0];
         let coord3 = vec![102.0, 0.8];
@@ -734,7 +734,7 @@ mod tests {
     }
 
     #[test]
-    fn geoson_polygon_conversion_test() {
+    fn geojson_polygon_conversion_test() {
         let coord1 = vec![100.0, 0.0];
         let coord2 = vec![101.0, 1.0];
         let coord3 = vec![101.0, 1.0];
@@ -781,7 +781,7 @@ mod tests {
     }
 
     #[test]
-    fn geoson_empty_polygon_conversion_test() {
+    fn geojson_empty_polygon_conversion_test() {
         let geojson_polygon = Value::Polygon(vec![]);
         let geo_polygon: geo_types::Polygon<f64> = geojson_polygon.try_into().unwrap();
 
@@ -789,7 +789,7 @@ mod tests {
     }
 
     #[test]
-    fn geoson_polygon_without_exterior_conversion_test() {
+    fn geojson_polygon_without_interiors_conversion_test() {
         let coord1 = vec![100.0, 0.0];
         let coord2 = vec![101.0, 1.0];
         let coord3 = vec![101.0, 1.0];
@@ -815,7 +815,7 @@ mod tests {
     }
 
     #[test]
-    fn geoson_multi_polygon_conversion_test() {
+    fn geojson_multi_polygon_conversion_test() {
         let coord1 = vec![100.0, 0.0];
         let coord2 = vec![101.0, 1.0];
         let coord3 = vec![101.0, 1.0];
@@ -865,7 +865,7 @@ mod tests {
     }
 
     #[test]
-    fn geoson_geometry_collection_conversion_test() {
+    fn geojson_geometry_collection_conversion_test() {
         let coord1 = vec![100.0, 0.0];
         let coord2 = vec![100.0, 1.0];
         let coord3 = vec![101.0, 1.0];

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -133,7 +133,7 @@ where
         .unwrap_or(create_geo_line_string(&vec![]));
 
     let interiors = if polygon_type.len() < 2 {
-        vec![create_geo_line_string(&vec![])]
+        vec![]
     } else {
         polygon_type[1..]
             .iter()
@@ -812,6 +812,8 @@ mod tests {
         assert_almost_eq!(geo_line_string1.0[2].y(), coord3[1], 1e-6);
         assert_almost_eq!(geo_line_string1.0[3].x(), coord1[0], 1e-6);
         assert_almost_eq!(geo_line_string1.0[3].y(), coord1[1], 1e-6);
+
+        assert_eq!(0, geo_polygon.interiors.len());
     }
 
     #[test]


### PR DESCRIPTION
I ran into what I think may be a small bug when using this library in a CLI tool I am working on.

It seems that when converting an exterior-only GeoJson polygon to a geo_types polygon, the library is injecting an empty interior ring rather than simply leaving the interiors field of the geo_types polygon empty.

This results in some surprising behavior if you do any round-trip conversions from geo_types -> GeoJson -> geo_types, since a polygon like this:

```json
{"type":"Polygon",
 "coordinates":[[[30.0, 10.0],[10.0, 30.0],[40.0, 40.0],[30.0, 10.0]]]}
```

becomes:

```json
{"type":"Polygon",
 "coordinates":[[[30.0, 10.0],[10.0, 30.0],[40.0, 40.0],[30.0, 10.0]], []]}
```

I've added a test case here which demonstrates the issue and included what I think is a reasonable approach to fixing it. Hope this is helpful!

I also fixed up a few test-name typos I noticed when I was reading these tests -- hope that is Ok.